### PR TITLE
fix(#7): Add a get hidden size helper fuction to better cover GGML mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Once the extension is enabled, it works automatically with no additional steps n
 | `keyword_grouping`          | Number to group keywords into. Higher values make it harder to find an exact match, potentially improving context relevance at the cost of memory retrieval. | `4` |
 | `maximum_memory_stack_size` | Maximum size for the memory stack, preventing overflow. | `50` |
 | `prompt_memory_ratio`       | The ratio of the prompt after character context is applied that will be dedicated for memories. | `0.4` |
+| `vector_dim_override` | Override value for the hidden layer dimension of your loaded model, Use if you encounter issues with the generated embeddings not matching the dimensionality of the annoy index. `-1` is disabled. | `-1` |
 
 These parameters allow you to tune the operation of `annoy_ltm` to best suit your specific use-case.
 


### PR DESCRIPTION
…dels and models that do not supply the hidden size in the config

Added in a override value for the hidden_size config property that is generally available on GPTQ models.
Created a _get_hidden_size helper function that first checks if the override is set, else looks for the config, and finally if all else fails, generates a set of embeddings and checks the length of the output to get the correct size.